### PR TITLE
Admin Portal Implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ gem "devise", "~> 4.9.4"
 gem "devise-jwt", "~> 0.12.1"
 gem "active_model_serializers", "~> 0.10.15"
 gem 'rswag', "~> 2.16.0"
+gem 'pagy', "~> 9.3.5"
+gem 'paranoia', "~> 3.0.1"
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,7 +230,10 @@ GEM
       racc (~> 1.4)
     orm_adapter (0.5.0)
     ostruct (0.6.2)
+    pagy (9.3.5)
     parallel (1.27.0)
+    paranoia (3.0.1)
+      activerecord (>= 6, < 8.1)
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
@@ -465,6 +468,8 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  pagy (~> 9.3.5)
+  paranoia (~> 3.0.1)
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,4 @@
+class Admin::BaseController < ApplicationController
+  before_action :authenticate_admin!
+  layout "admin"
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,0 +1,6 @@
+class Admin::DashboardController < Admin::BaseController
+  include Pagy::Backend
+  def index
+    @pagy, @tickets = pagy(Ticket.order(created_at: :desc))
+  end
+end

--- a/app/controllers/admin/tickets_controller.rb
+++ b/app/controllers/admin/tickets_controller.rb
@@ -1,0 +1,17 @@
+class Admin::TicketsController < Admin::BaseController
+  before_action :set_ticket, only: [:show, :destroy]
+
+  def show
+  end
+
+  def destroy
+    @ticket.destroy
+    redirect_to admin_dashboard_path, notice: "Ticket was successfully soft deleted."
+  end
+
+  private
+
+  def set_ticket
+    @ticket = Ticket.find(params[:id])
+  end
+end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::Auth::RegistrationsController < Devise::RegistrationsController
-  include ApiResponse
+  include ExceptionHandler
 
   skip_before_action :verify_authenticity_token
   respond_to :json

--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::Auth::SessionsController < Devise::SessionsController
-  include ApiResponse
+  include ExceptionHandler
   skip_before_action :verify_authenticity_token
   respond_to :json
 
@@ -22,7 +22,8 @@ class Api::V1::Auth::SessionsController < Devise::SessionsController
     end
   end
 
-  def respond_to_on_destroy
+  def destroy
+    sign_out(:user) 
     render_success(message: "Logged out successfully")
   end
 

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,4 +1,4 @@
 class Api::V1::BaseController < ApplicationController
-  include ApiResponse
+  include ExceptionHandler
   before_action :authenticate_user!
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,19 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+  protected
+
+  # Custom redirect path after sign in
+  def after_sign_in_path_for(resource)
+    return admin_dashboard_path if resource.is_a?(Admin)
+
+    super
+  end
+
+  # Custom redirect path after sign out
+  def after_sign_out_path_for(resource_or_scope)
+    return new_admin_session_path if resource_or_scope == :admin
+
+    super
+  end
 end

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -1,0 +1,39 @@
+module ExceptionHandler
+  extend ActiveSupport::Concern
+  
+  include ApiResponse
+
+  included do
+    rescue_from ActiveRecord::RecordNotFound,        with: :handle_not_found
+    rescue_from ActiveRecord::RecordInvalid,         with: :handle_unprocessable_entity
+    rescue_from StandardError,                       with: :handle_internal_error
+  end
+
+  private
+
+  def handle_not_found(error)
+    render_error(
+      message: "Record not found",
+      errors: [error.message],
+      status: :not_found
+    )
+  end
+
+  def handle_unprocessable_entity(error)
+    render_error(
+      message: "Unprocessable entity",
+      errors: [error.record.errors.full_messages],
+      status: :unprocessable_entity
+    )
+  end
+
+  def handle_internal_error(error)
+    logger.error error.full_message
+    render_error(
+      message: "Internal server error",
+      errors: [error.message],
+      status: :internal_server_error
+    )
+  end
+  
+end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  def show
+    self.resource = resource_class.confirm_by_token(params[:confirmation_token])
+    render :show 
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,3 @@
 module ApplicationHelper
+  include Pagy::Frontend
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: admins
+#
+#  id                     :bigint           not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_admins_on_email                 (email) UNIQUE
+#  index_admins_on_reset_password_token  (reset_password_token) UNIQUE
+#
+class Admin < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  devise :database_authenticatable, :rememberable, :validatable
+end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -3,6 +3,7 @@
 # Table name: tickets
 #
 #  id               :bigint           not null, primary key
+#  deleted_at       :datetime
 #  email            :string
 #  name             :string
 #  phone_number     :string
@@ -17,12 +18,14 @@
 #
 # Indexes
 #
-#  index_tickets_on_user_id  (user_id)
+#  index_tickets_on_deleted_at  (deleted_at)
+#  index_tickets_on_user_id     (user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (user_id => users.id)
 #
 class Ticket < ApplicationRecord
+  acts_as_paranoid
   belongs_to :user, optional: true
 end

--- a/app/serializers/ticket_serializer.rb
+++ b/app/serializers/ticket_serializer.rb
@@ -1,3 +1,30 @@
+# == Schema Information
+#
+# Table name: tickets
+#
+#  id               :bigint           not null, primary key
+#  deleted_at       :datetime
+#  email            :string
+#  name             :string
+#  phone_number     :string
+#  state            :string
+#  tito_created_at  :datetime
+#  tito_info        :jsonb
+#  tito_ticket_slug :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  tito_ticket_id   :integer
+#  user_id          :bigint
+#
+# Indexes
+#
+#  index_tickets_on_deleted_at  (deleted_at)
+#  index_tickets_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 class TicketSerializer < ActiveModel::Serializer
 
   attributes :id, :name, :email, :phone_number, :state, :tito_ticket_id, :tito_ticket_slug

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  unconfirmed_email      :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 class UserSerializer < ActiveModel::Serializer
   attributes :id, :email
   has_many :tickets, if: :include_tickets?

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,0 +1,31 @@
+<h1>Admin Dashboard</h1>
+<table>
+  <thead>
+    <tr>
+      <th>Ticket ID</th>
+      <th>Name</th>
+      <th>Email</th>
+      <th>Status</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @tickets.each do |ticket| %>
+      <tr>
+        <td><%= ticket.tito_ticket_id %></td>
+        <td><%= ticket.name %></td>
+        <td><%= ticket.email %></td>
+        <td><%= ticket.state %></td>
+        <td>
+          <%= link_to "Details", admin_ticket_path(ticket) %> |
+          <%= button_to "Delete", admin_ticket_path(ticket),
+              method: :delete,
+              data: { confirm: "Are you sure you want to delete this ticket?" } %>
+
+
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<%= raw pagy_nav(@pagy) %>

--- a/app/views/admin/tickets/show.html.erb
+++ b/app/views/admin/tickets/show.html.erb
@@ -1,0 +1,9 @@
+<h1>Ticket Details</h1>
+
+<p><strong>Ticket ID:</strong> <%= @ticket.tito_ticket_id %></p>
+<p><strong>Status:</strong> <%= @ticket.state %></p>
+<p><strong>Name:</strong> <%= @ticket.name %></p>
+<p><strong>Email:</strong> <%= @ticket.email %></p>
+<p><strong>Phone Number:</strong> <%= @ticket.phone_number %></p>
+
+<%= link_to "Back to Dashboard", admin_dashboard_path %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Admin Portal</title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "application", media: "all" %>
+  </head>
+  <body>
+    <nav>
+      <%= link_to "Dashboard", admin_dashboard_path %> |
+      <%= button_to "Logout", destroy_admin_session_path, method: :delete, form: { data: { turbo: false } } %>
+    </nav>
+
+    <%= yield %>
+  </body>
+</html>

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -15,7 +15,8 @@ echo "Postgres is up - running Sidekiq"
 bundle install
 
 # Run any pending migrations
-bundle exec rails db:prepare
+bundle exec rails db:migrate
+bundle exec rails db:seed
 
 # Execute the container’s main process
 exec "$@"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -263,7 +263,7 @@ Devise.setup do |config|
   # should add them to the navigational formats lists.
   #
   # The "*/*" below is required to match Internet Explorer requests.
-  config.navigational_formats = []
+  config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
   config.sign_out_via = :delete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   mount Rswag::Ui::Engine => '/api-docs'
   mount Rswag::Api::Engine => '/api-docs'
-  devise_for :users
+  devise_for :users, controllers: {
+    confirmations: 'users/confirmations'
+  }, skip: [:sessions, :registrations, :passwords]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
@@ -21,6 +23,18 @@ Rails.application.routes.draw do
   ##### Webhooks Endpoints #####
   post "/webhooks/tito/sync_tickets", to: "webhooks/tito#sync_tickets"
 
+  ##### Admin Endpoints #####
+  devise_for :admins
+
+  namespace :admin do
+    get 'dashboard', to: 'dashboard#index'
+    resources :tickets, only: [:index, :show, :destroy]
+  end
+
+  
+  ##### API Endpoints #####
+
+  # API v1
   namespace :api do
     namespace :v1 do
       namespace :auth do

--- a/db/migrate/20250719175026_devise_create_admins.rb
+++ b/db/migrate/20250719175026_devise_create_admins.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class DeviseCreateAdmins < ActiveRecord::Migration[8.0]
+  def change
+    create_table :admins do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.string   :current_sign_in_ip
+      # t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+
+      t.timestamps null: false
+    end
+
+    add_index :admins, :email,                unique: true
+    add_index :admins, :reset_password_token, unique: true
+    # add_index :admins, :confirmation_token,   unique: true
+    # add_index :admins, :unlock_token,         unique: true
+  end
+end

--- a/db/migrate/20250719223125_add_deleted_at_to_tickets.rb
+++ b/db/migrate/20250719223125_add_deleted_at_to_tickets.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToTickets < ActiveRecord::Migration[8.0]
+  def change
+    add_column :tickets, :deleted_at, :datetime
+    add_index :tickets, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_16_131045) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_19_223125) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "admins", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_admins_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+  end
 
   create_table "jwt_denylists", force: :cascade do |t|
     t.string "jti"
@@ -34,6 +46,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_16_131045) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.datetime "deleted_at"
+    t.index ["deleted_at"], name: "index_tickets_on_deleted_at"
     t.index ["user_id"], name: "index_tickets_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,12 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+puts "Seeding admin user..."
+
+Admin.find_or_create_by!(email: "admin@example.com") do |admin|
+  admin.password = "pass@1234"
+  admin.password_confirmation = "pass@1234"
+end
+
+puts "Admin user created: admin@example.com / pass@1234"

--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: admins
+#
+#  id                     :bigint           not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_admins_on_email                 (email) UNIQUE
+#  index_admins_on_reset_password_token  (reset_password_token) UNIQUE
+#
+FactoryBot.define do
+  factory :admin do
+    email { Faker::Internet.email }
+    password { "password123" }
+    password_confirmation { "password123" }
+  end
+end

--- a/spec/factories/tickets.rb
+++ b/spec/factories/tickets.rb
@@ -3,6 +3,7 @@
 # Table name: tickets
 #
 #  id               :bigint           not null, primary key
+#  deleted_at       :datetime
 #  email            :string
 #  name             :string
 #  phone_number     :string
@@ -17,7 +18,8 @@
 #
 # Indexes
 #
-#  index_tickets_on_user_id  (user_id)
+#  index_tickets_on_deleted_at  (deleted_at)
+#  index_tickets_on_user_id     (user_id)
 #
 # Foreign Keys
 #

--- a/spec/requests/api/v1/profile_spec.rb
+++ b/spec/requests/api/v1/profile_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Api::V1::Profile", type: :request do
 
     context "when unauthenticated" do
       it "returns 401 unauthorized" do
-        get "/api/v1/profile"
+        get "/api/v1/profile", headers: { "Accept" => "application/json" }
         expect(response).to have_http_status(:unauthorized)
       end
     end

--- a/spec/requests/api/v1/tickets_spec.rb
+++ b/spec/requests/api/v1/tickets_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "API::V1::Tickets", type: :request do
 
     context "when user is unauthenticated" do
       it "returns 401 unauthorized" do
-        get "/api/v1/tickets/1" 
+        get "/api/v1/tickets/1", headers: { "Accept" => "application/json" }
 
         expect(response).to have_http_status(:unauthorized)
       end

--- a/spec/serializers/ticket_serializer_spec.rb
+++ b/spec/serializers/ticket_serializer_spec.rb
@@ -1,3 +1,30 @@
+# == Schema Information
+#
+# Table name: tickets
+#
+#  id               :bigint           not null, primary key
+#  deleted_at       :datetime
+#  email            :string
+#  name             :string
+#  phone_number     :string
+#  state            :string
+#  tito_created_at  :datetime
+#  tito_info        :jsonb
+#  tito_ticket_slug :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  tito_ticket_id   :integer
+#  user_id          :bigint
+#
+# Indexes
+#
+#  index_tickets_on_deleted_at  (deleted_at)
+#  index_tickets_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 require "rails_helper"
 
 RSpec.describe TicketSerializer, type: :serializer do

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  unconfirmed_email      :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 require "rails_helper"
 
 RSpec.describe UserSerializer, type: :serializer do


### PR DESCRIPTION
####  Summary

This PR adds a complete **Admin Portal** to the event admission platform, enabling internal admins to securely manage ticket records synced from the Tito API. It includes authentication, UI, pagination, ticket detail views, and soft deletion.

---

#### Features Implemented

##### Admin Authentication

* Added `Admin` model with Devise (session-based).
* Configured separate `devise_for :admins` with custom redirects.
* Admin sign-in/sign-out implemented under `/admins/sign_in`.

##### Admin Dashboard

* Created `Admin::DashboardController#index` to list all non-deleted tickets.
* Used `pagy` for pagination.
* Tickets are ordered by most recent first.

##### Ticket Details View

* Created `Admin::TicketsController#show`.
* Admins can click “Details” to view full info:

  * `Ticket ID`, `Name`, `Email`, `Status`, `Phone`

#####  Soft Deletion

* Integrated [`[paranoia](https://github.com/rubysherpas/paranoia)`](https://github.com/rubysherpas/paranoia) gem.
* Admins can delete a ticket (soft delete using `deleted_at`).
* Deleted tickets are excluded from the dashboard but remain in DB.

##### Pagination (Pagy)

* Configured `pagy` with admin views.


#####  UI Enhancements

* Simple and clear `admin.html.erb` layout.
* Added logout link with working Turbo and method delete behavior.
* Removed “Forgot Password” from admin login for security clarity.

---

#### Configuration & Cleanup

* Added admin user creation to `db/seeds.rb`.
* Ensured Devise user routes (sign in/up) are disabled in browser — API-only for users.
